### PR TITLE
nativeSpec as CamelCase, fix rules structure, store spec status as st…

### DIFF
--- a/apis/druid/v1alpha1/druidingestion_types.go
+++ b/apis/druid/v1alpha1/druidingestion_types.go
@@ -48,14 +48,14 @@ type IngestionSpec struct {
 	Type DruidIngestionMethod `json:"type"`
 	// +optional
 	// Spec should be passed in as a JSON string.
-	// Note: This field is planned for deprecation in favor of NativeSpec.
+	// Note: This field is planned for deprecation in favor of nativeSpec.
 	Spec string `json:"spec,omitempty"`
 	// +optional
-	// NativeSpec allows the ingestion specification to be defined in a native Kubernetes format.
+	// nativeSpec allows the ingestion specification to be defined in a native Kubernetes format.
 	// This is particularly useful for environment-specific configurations and will eventually
 	// replace the JSON-based Spec field.
-	// Note: Spec will be ignored if NativeSpec is provided.
-	NativeSpec runtime.RawExtension `json:"NativeSpec,omitempty"`
+	// Note: Spec will be ignored if nativeSpec is provided.
+	NativeSpec runtime.RawExtension `json:"nativeSpec,omitempty"`
 	// +optional
 	Compaction runtime.RawExtension `json:"compaction,omitempty"`
 	// +optional
@@ -63,13 +63,15 @@ type IngestionSpec struct {
 }
 
 type DruidIngestionStatus struct {
-	TaskId               string                 `json:"taskId"`
-	Type                 string                 `json:"type,omitempty"`
-	Status               v1.ConditionStatus     `json:"status,omitempty"`
-	Reason               string                 `json:"reason,omitempty"`
-	Message              string                 `json:"message,omitempty"`
-	LastUpdateTime       metav1.Time            `json:"lastUpdateTime,omitempty"`
-	CurrentIngestionSpec runtime.RawExtension   `json:"currentIngestionSpec.json"`
+	TaskId         string             `json:"taskId"`
+	Type           string             `json:"type,omitempty"`
+	Status         v1.ConditionStatus `json:"status,omitempty"`
+	Reason         string             `json:"reason,omitempty"`
+	Message        string             `json:"message,omitempty"`
+	LastUpdateTime metav1.Time        `json:"lastUpdateTime,omitempty"`
+	// CurrentIngestionSpec is a string instead of RawExtension to maintain compatibility with existing
+	// IngestionSpecs that are stored as JSON strings.
+	CurrentIngestionSpec string                 `json:"currentIngestionSpec.json"`
 	CurrentCompaction    runtime.RawExtension   `json:"compaction,omitempty"`
 	CurrentRules         []runtime.RawExtension `json:"rules,omitempty"`
 }

--- a/apis/druid/v1alpha1/zz_generated.deepcopy.go
+++ b/apis/druid/v1alpha1/zz_generated.deepcopy.go
@@ -286,7 +286,6 @@ func (in *DruidIngestionSpec) DeepCopy() *DruidIngestionSpec {
 func (in *DruidIngestionStatus) DeepCopyInto(out *DruidIngestionStatus) {
 	*out = *in
 	in.LastUpdateTime.DeepCopyInto(&out.LastUpdateTime)
-	in.CurrentIngestionSpec.DeepCopyInto(&out.CurrentIngestionSpec)
 	in.CurrentCompaction.DeepCopyInto(&out.CurrentCompaction)
 	if in.CurrentRules != nil {
 		in, out := &in.CurrentRules, &out.CurrentRules

--- a/chart/crds/druid.apache.org_druidingestions.yaml
+++ b/chart/crds/druid.apache.org_druidingestions.yaml
@@ -72,15 +72,15 @@ spec:
                 type: string
               ingestion:
                 properties:
-                  NativeSpec:
-                    description: |-
-                      NativeSpec allows the ingestion specification to be defined in a native Kubernetes format.
-                      This is particularly useful for environment-specific configurations and will eventually
-                      replace the JSON-based Spec field.
-                      Note: Spec will be ignored if NativeSpec is provided.
+                  compaction:
                     type: object
                     x-kubernetes-preserve-unknown-fields: true
-                  compaction:
+                  nativeSpec:
+                    description: |-
+                      nativeSpec allows the ingestion specification to be defined in a native Kubernetes format.
+                      This is particularly useful for environment-specific configurations and will eventually
+                      replace the JSON-based Spec field.
+                      Note: Spec will be ignored if nativeSpec is provided.
                     type: object
                     x-kubernetes-preserve-unknown-fields: true
                   rules:
@@ -91,7 +91,7 @@ spec:
                   spec:
                     description: |-
                       Spec should be passed in as a JSON string.
-                      Note: This field is planned for deprecation in favor of NativeSpec.
+                      Note: This field is planned for deprecation in favor of nativeSpec.
                     type: string
                   type:
                     type: string
@@ -110,8 +110,10 @@ spec:
                 type: object
                 x-kubernetes-preserve-unknown-fields: true
               currentIngestionSpec.json:
-                type: object
-                x-kubernetes-preserve-unknown-fields: true
+                description: |-
+                  CurrentIngestionSpec is a string instead of RawExtension to maintain compatibility with existing
+                  IngestionSpecs that are stored as JSON strings.
+                type: string
               lastUpdateTime:
                 format: date-time
                 type: string

--- a/config/crd/bases/druid.apache.org_druidingestions.yaml
+++ b/config/crd/bases/druid.apache.org_druidingestions.yaml
@@ -72,15 +72,15 @@ spec:
                 type: string
               ingestion:
                 properties:
-                  NativeSpec:
-                    description: |-
-                      NativeSpec allows the ingestion specification to be defined in a native Kubernetes format.
-                      This is particularly useful for environment-specific configurations and will eventually
-                      replace the JSON-based Spec field.
-                      Note: Spec will be ignored if NativeSpec is provided.
+                  compaction:
                     type: object
                     x-kubernetes-preserve-unknown-fields: true
-                  compaction:
+                  nativeSpec:
+                    description: |-
+                      nativeSpec allows the ingestion specification to be defined in a native Kubernetes format.
+                      This is particularly useful for environment-specific configurations and will eventually
+                      replace the JSON-based Spec field.
+                      Note: Spec will be ignored if nativeSpec is provided.
                     type: object
                     x-kubernetes-preserve-unknown-fields: true
                   rules:
@@ -91,7 +91,7 @@ spec:
                   spec:
                     description: |-
                       Spec should be passed in as a JSON string.
-                      Note: This field is planned for deprecation in favor of NativeSpec.
+                      Note: This field is planned for deprecation in favor of nativeSpec.
                     type: string
                   type:
                     type: string
@@ -110,8 +110,10 @@ spec:
                 type: object
                 x-kubernetes-preserve-unknown-fields: true
               currentIngestionSpec.json:
-                type: object
-                x-kubernetes-preserve-unknown-fields: true
+                description: |-
+                  CurrentIngestionSpec is a string instead of RawExtension to maintain compatibility with existing
+                  IngestionSpecs that are stored as JSON strings.
+                type: string
               lastUpdateTime:
                 format: date-time
                 type: string

--- a/e2e/configs/kafka-ingestion-native.yaml
+++ b/e2e/configs/kafka-ingestion-native.yaml
@@ -25,7 +25,7 @@ spec:
     - type: broadcastByPeriod
       period: P1M
       includeFuture: true
-    NativeSpec:
+    nativeSpec:
       type: kafka
       spec:
         dataSchema:


### PR DESCRIPTION
…ring to keep backward compatibility

<!-- Thanks for trying to help us make Druid Operator be the best it can be! Please fill out as much of the following information as is possible (where relevant, and remove it when irrelevant) to help make the intention and scope of this PR clear in order to ease review. -->

Fixes #XXXX.

<!-- Replace XXXX with the id of the issue fixed in this PR. Remove this section if there is no corresponding issue. Don't reference the issue in the title of this pull-request. -->

### Description

<!-- Describe the goal of this PR and the problem you encoutered while managing Druid clusters. Something like, "I have a Druid cluster managed with this operator and wanted to change XX on the cluster to enable YY usecase that I needed due to ZZ requirement.". If there is a corresponding issue (referenced above), it's not necessary to repeat the description here, however, you may choose to keep one summary sentence. -->

<!-- Describe the possible solutions and chosen one with the rationale. -->

<!-- Describe key changes made in the patch. -->

<hr>

This PR has:
- [ ] been tested on a real K8S cluster to ensure creation of a brand new Druid cluster works.
- [ ] been tested for backward compatibility on a real K*S cluster by applying the changes introduced here on an existing Druid cluster. If there are any backward incompatible changes then they have been noted in the PR description.
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added documentation for new or modified features or behaviors.

<hr>

##### Key changed/added files in this PR
 * `MyFoo`
 * `OurBar`
 * `TheirBaz`
